### PR TITLE
Refactor: Simplifies the creation of children in the statements parser

### DIFF
--- a/src/expressionParser.c
+++ b/src/expressionParser.c
@@ -57,7 +57,7 @@ node parseLiteralArray() {
     // Alternate between expressions and commas until a right bracket is found
     while (1) {
         // Parse expression
-        addChild(array, getExpressionAST(0));
+        parseExpression(&array);
 
         if (tokenListManagerRef->tokens[tokenListManagerRef->index].type == COMMA) {
             tokenListManagerRef->index++;
@@ -120,7 +120,7 @@ node getOperand() {
     // Verify if is a unary operator
     else if (tokenListManagerRef->tokens[tokenListManagerRef->index].type >> 4 == 0x07) {
         node rootOperation;
-        rootOperation.length = 0;
+        rootOperation.length = 1;
         rootOperation.children = (node *) malloc(sizeof(node));
 
         // Get the operator
@@ -129,7 +129,7 @@ node getOperand() {
         tokenListManagerRef->index++;
 
         // Get the operand
-        addChild(rootOperation, getOperand());
+        rootOperation.children[0] = getOperand();
 
         return rootOperation;
     }
@@ -156,9 +156,9 @@ node getExpressionAST(int minPrecedence) {
         }
 
         node rootOperation;
-        rootOperation.length = 0;
-        rootOperation.children = (node *) malloc(sizeof(node));
-        addChild(rootOperation, childNode);
+        rootOperation.length = 2;
+        rootOperation.children = (node *) malloc(2 * sizeof(node));
+        rootOperation.children[0] = childNode;
 
         // Get the operator
         rootOperation.data = tokenListManagerRef->tokens[tokenListManagerRef->index];
@@ -166,7 +166,7 @@ node getExpressionAST(int minPrecedence) {
         tokenListManagerRef->index++;
 
         // Get the second operand
-        addChild(rootOperation, getExpressionAST(getOperatorPrecedence(rootOperation.data)));
+        rootOperation.children[1] = getExpressionAST(getOperatorPrecedence(rootOperation.data));
 
         childNode = rootOperation;
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -4,53 +4,61 @@
 #include "parser.h"
 #include "expressionParser.h"
 
-node parseStatement();
-node parseBlock();
+void parseStatement(node* parent);
+void parseBlock(node* parent);
 TLM tokenListManager;
 
-void addChild(node parent, node child)
-{
-    parent.length++;
-    if (parent.length > 1)
-        parent.children = (node *) realloc(parent.children, sizeof(node) * parent.length);
-    parent.children[parent.length - 1] = child;
-}
 
-void addNChildren(node parent, node* children, int n)
+
+node* addNChildren(node* parent, int n)
 {
 
-    printf("Adding %d children from %x to %x ...\n", n, children, parent.children);
-    parent.length += n;
-    if (parent.length > 1) {
-        printf("Increasing capacity of node %x for %d children = %d bytes\n", parent.children, parent.length, sizeof(node) * parent.length);
-        parent.children = (node *) realloc(parent.children, sizeof(node) * parent.length);
+    printf("Adding %d children to %x ...\n", n, parent->children);
+    parent->length += n;
+    if (parent->length > 1) {
+        printf("Increasing capacity of node %x for %d children = %d bytes\n", parent->children, parent->length, sizeof(node) * parent->length);
+        parent->children = (node *) realloc(parent->children, sizeof(node) * parent->length);
     }
-    for (int i = parent.length - n; i < parent.length; i++)
-        parent.children[i] = children[i - parent.length];
+    return parent->children + parent->length - n;
 }
 
-node parseExpression() {
-    node expression;
-    expression.data.type = EXPRESSION;
-    expression.length = 0;
-    expression.children = (node*) malloc(sizeof(node));
 
-    node expressionRootOperation = getExpressionAST(0);
-    addChild(expression, expressionRootOperation);
-
-    return expression;
+node* addChild(node* parent)
+{
+    return addNChildren(parent, 1);
 }
 
-node parseDeclaration() {
-    node declaration;
-    declaration.data.type = DECLARATION;
-    declaration.length = 0;
-    declaration.children = (node*) malloc(sizeof(node));
+
+void parseExpression(node* parent) {
+    node* expression = addChild(parent);
+    expression->data.type = EXPRESSION;
+    expression->length = 0;
+    expression->children = (node*) malloc(sizeof(node));
+
+    expression->children[0] = getExpressionAST(0);
+
+    return;
+}
+
+void parseDeclaration(node* parent) {
+    node* declaration = addChild(parent);
+    declaration->data.type = DECLARATION;
+    declaration->length = 0;
+    declaration->children = (node*) malloc(sizeof(node));
 
     // Verify declaration
     if (isAType(tokenListManager.tokens[tokenListManager.index])) {
+        node* type = addChild(declaration);
+        type->data = tokenListManager.tokens[tokenListManager.index];
+        type->length = 0;
+        type->children = (node*) malloc(sizeof(node));
         tokenListManager.index++;
+
         if (tokenListManager.tokens[tokenListManager.index].type == VAR) {
+            node* symbol = addChild(declaration);
+            symbol->data = tokenListManager.tokens[tokenListManager.index];
+            symbol->length = 0;
+            symbol->children = (node*) malloc(sizeof(node));
             tokenListManager.index++;
             if (tokenListManager.tokens[tokenListManager.index].type == ASSIGN)
                 tokenListManager.index--;
@@ -60,214 +68,225 @@ node parseDeclaration() {
         }
     }
 
-    return declaration;
+    return;
 }
 
-node parseIfStatement() {
-    node ifElseStatement;
-    ifElseStatement.data.type = IFSTATEMENT;
-    ifElseStatement.length = 0;
-    ifElseStatement.children = (node*) malloc(sizeof(node));
+void parseIfStatement(node* parent) {
+    node* ifElseStatement = addChild(parent);
+    ifElseStatement->data.type = IFSTATEMENT;
+    ifElseStatement->length = 0;
+    ifElseStatement->children = (node*) malloc(sizeof(node));
 
     // Verify if statement
     if (tokenListManager.tokens[tokenListManager.index].type == IF) {
         tokenListManager.index++;
-        addChild(ifElseStatement, parseExpression());
-        addChild(ifElseStatement, parseStatement());
+        parseExpression(ifElseStatement);
+        parseStatement(ifElseStatement);
     }
 
     // Verify else statement
     if (tokenListManager.tokens[tokenListManager.index].type == ELSE) {
         tokenListManager.index++;
-        addChild(ifElseStatement, parseStatement());
+        parseStatement(ifElseStatement);
     }
 
-    return ifElseStatement;
+    return;
 }
 
-node parseWhileLoop() {
-    node whileLoop;
-    whileLoop.data.type = WHILELOOPSTATEMENT;
-    whileLoop.length = 0;
-    whileLoop.children = (node*) malloc(sizeof(node));
+void parseWhileLoop(node* parent) {
+    node* whileLoop = addChild(parent);
+    whileLoop->data.type = WHILELOOPSTATEMENT;
+    whileLoop->length = 0;
+    whileLoop->children = (node*) malloc(sizeof(node));
 
     // Verify while loop
     if (tokenListManager.tokens[tokenListManager.index].type == WHILE) {
         tokenListManager.index++;
-        addChild(whileLoop, parseExpression());
-        addChild(whileLoop, parseStatement());
+        parseExpression(whileLoop);
+        parseStatement(whileLoop);
     }
 
-    return whileLoop;
+    return;
 }
 
-node parseDoWhileLoop() {
-    node doWhileLoop;
-    doWhileLoop.data.type = DOWHILELOOPSTATEMENT;
-    doWhileLoop.length = 0;
-    doWhileLoop.children = (node*) malloc(sizeof(node));
+void parseDoWhileLoop(node* parent) {
+    node* doWhileLoop = addChild(parent);
+    doWhileLoop->data.type = DOWHILELOOPSTATEMENT;
+    doWhileLoop->length = 0;
+    doWhileLoop->children = (node*) malloc(sizeof(node));
 
     // Verify do while loop
     if (tokenListManager.tokens[tokenListManager.index].type == DO) {
         tokenListManager.index++;
-        addChild(doWhileLoop, parseStatement());
+        parseStatement(doWhileLoop);
         if (tokenListManager.tokens[tokenListManager.index].type == WHILE) {
             tokenListManager.index++;
-            addChild(doWhileLoop, parseExpression());
+            parseExpression(doWhileLoop);
         } else {
-            exit(1);
             printf("Error: expected 'while' at line %d\n", tokenListManager.tokens[tokenListManager.index].line);
+            exit(1);
         }
     }
 
     return doWhileLoop;
 }
 
-node parseForLoop() {
-    node forLoopStatement;
-    forLoopStatement.data.type = FORLOOPSTATEMENT;
-    forLoopStatement.length = 0;
-    forLoopStatement.children = (node*) malloc(sizeof(node));
+node parseForLoop(node* parent) {
+    node* forLoopStatement = addChild(parent);
+    forLoopStatement->data.type = FORLOOPSTATEMENT;
+    forLoopStatement->length = 0;
+    forLoopStatement->children = (node*) malloc(sizeof(node));
 
     // Verify for loop
     if (tokenListManager.tokens[tokenListManager.index].type == FOR) {
         tokenListManager.index++;
         if (tokenListManager.tokens[tokenListManager.index].type == LBRACK) {
             tokenListManager.index++;
-            addChild(forLoopStatement, parseStatement());
-            addChild(forLoopStatement, parseExpression());
-            addChild(forLoopStatement, parseStatement());
+            parseStatement(forLoopStatement);
+            parseExpression(forLoopStatement);
+            if (tokenListManager.tokens[tokenListManager.index].type == SEMICOLON) {
+                tokenListManager.index++;
+            } else {
+                printf("Error: expected ';' at line %d\n", tokenListManager.tokens[tokenListManager.index].line);
+                exit(1);
+            }
+            parseStatement(forLoopStatement);
             if (tokenListManager.tokens[tokenListManager.index].type == RBRACK) {
                 tokenListManager.index++;
-                addChild(forLoopStatement, parseStatement());
+                parseStatement(forLoopStatement);
             } else {
-                exit(1);
                 printf("Error: expected ')' at line %d\n", tokenListManager.tokens[tokenListManager.index].line);
+                exit(1);
             }
         } else {
-            exit(1);
             printf("Error: expected '(' at line %d\n", tokenListManager.tokens[tokenListManager.index].line);
+            exit(1);
         }
     }
 
-    return forLoopStatement;
+    return;
 }
 
-node parseBreakStatement() {
-    node breakStatement;
-    breakStatement.data.type = BREAK;
-    breakStatement.length = 0;
+void parseBreakStatement(node* parent) {
+    node* breakStatement = addChild(parent);
+    breakStatement->data.type = BREAK;
+    breakStatement->length = 0;
 
     // Verify break statement
     if (tokenListManager.tokens[tokenListManager.index].type == BREAK) {
         tokenListManager.index++;
+    } else {
+        printf("Error: expected 'break' at line %d\n", tokenListManager.tokens[tokenListManager.index].line);
+        exit(1);
     }
 
-    return breakStatement;
+    return;
 }
 
-node parseContinueStatement() {
-    node continueStatement;
-    continueStatement.data.type = CONTINUE;
-    continueStatement.length = 0;
+void parseContinueStatement(node* parent) {
+    node* continueStatement = addChild(parent);
+    continueStatement->data.type = CONTINUE;
+    continueStatement->length = 0;
 
     // Verify continue statement
     if (tokenListManager.tokens[tokenListManager.index].type == CONTINUE) {
         tokenListManager.index++;
+    } else {
+        printf("Error: expected 'continue' at line %d\n", tokenListManager.tokens[tokenListManager.index].line);
+        exit(1);
     }
 
-    return continueStatement;
+    return;
 }
 
-node parseReturnStatement() {
-    node returnStatement;
-    returnStatement.data.type = RETURN;
-    returnStatement.length = 0;
-    returnStatement.children = (node*) malloc(sizeof(node));
+void parseReturnStatement(node* parent) {
+    node* returnStatement = addChild(parent);
+    returnStatement->data.type = RETURN;
+    returnStatement->length = 0;
+    returnStatement->children = (node*) malloc(sizeof(node));
 
     // Verify return statement
     if (tokenListManager.tokens[tokenListManager.index].type == RETURN) {
         tokenListManager.index++;
-        addChild(returnStatement, parseExpression());
+        parseExpression(returnStatement);
     }
 
     return returnStatement;
 }
 
-node parseStatement()
+void parseStatement(node* parent)
 {
-    node statement;
-
     // Verify block
     if (tokenListManager.tokens[tokenListManager.index].type == LBRACE) {
-        statement = parseBlock();
-        return statement;
+        parseBlock(parent);
     }
 
     // Verify declaration
     else if (isAType(tokenListManager.tokens[tokenListManager.index])) {
         printf("Declaration\n");
-        statement = parseDeclaration();
+        parseDeclaration(parent);
     }
 
     // Verify while loop
     else if (tokenListManager.tokens[tokenListManager.index].type == WHILE) {
         printf("While\n");
-        statement = parseWhileLoop();
+        parseWhileLoop(parent);
     }
 
     // Verify do while loop
     else if (tokenListManager.tokens[tokenListManager.index].type == DO) {
         printf("Do while\n");
-        statement = parseDoWhileLoop();
+        parseDoWhileLoop(parent);
     }
 
     // Verify for loop
     else if (tokenListManager.tokens[tokenListManager.index].type == FOR) {
         printf("For\n");
-        statement = parseForLoop();
+        parseForLoop(parent);
     }
 
     // Verify if statement
     else if (tokenListManager.tokens[tokenListManager.index].type == IF) {
         printf("If\n");
-        statement = parseIfStatement();
+        parseIfStatement(parent);
     }
 
     // Verify return statement
     else if (tokenListManager.tokens[tokenListManager.index].type == RETURN) {
         printf("Return\n");
-        statement = parseReturnStatement();
+        parseReturnStatement(parent);
     }
 
     // Verify break statement
     else if (tokenListManager.tokens[tokenListManager.index].type == BREAK) {
         printf("Break\n");
-        statement = parseBreakStatement();
+        parseBreakStatement(parent);
     }
 
     // Verify continue statement
     else if (tokenListManager.tokens[tokenListManager.index].type == CONTINUE) {
         printf("Continue\n");
-        statement = parseContinueStatement();
+        parseContinueStatement(parent);
     }
 
     // Verify expression
     else if (tokenListManager.tokens[tokenListManager.index].type == VAR || isAnOperator(tokenListManager.tokens[tokenListManager.index]) || isALiteral(tokenListManager.tokens[tokenListManager.index])) {
         printf("Expression\n");
-        statement = parseExpression();
+        parseExpression(parent);
     }
 
     // Verify if is the End Of File
     else if (tokenListManager.tokens[tokenListManager.index].type == EOF) {
         printf("EOF\n");
-        statement.data.type = EOF;
+        node* eofNode = addChild(parent);
+        eofNode->data.type = EOF;
     }
 
     // Verify if is the end of a block
     else if (tokenListManager.tokens[tokenListManager.index].type == RBRACE) {
         printf("End of block\n");
-        statement.data.type = EOF;
+        node* eofNode = addChild(parent);
+        eofNode->data.type = EOF;
     }
 
     else {
@@ -280,35 +299,23 @@ node parseStatement()
         tokenListManager.index++;
     }
 
-    return statement;
+    return;
 }
 
-node* parseStatementList()
+void parseStatementList(node* parent)
 {
-    node* statementList = (node *) malloc(2 * sizeof(node));
-    printf("New statementList address %x\n", statementList);
-    int length = 0;
-    int capacity = 2;
     while (1) {
-        if (++length > capacity) {
-            capacity <<= 1;
-            printf("Allocating to statementList (address %x) %d nodes (%d bytes per node) = %d bytes\n", statementList, capacity, sizeof(node), capacity * sizeof(node));
-            statementList = (node *) realloc(statementList, sizeof(node) * capacity);
-            printf("New address %x\n", statementList);
-
-        }
-        statementList[length - 1] = parseStatement();
-        if (statementList[length - 1].data.type == EOF) break;
+        parseStatement(parent);
+        if (parent->children[parent->length - 1].data.type == EOF) break;
     }
-    return statementList;
 }
 
-node parseBlock()
+void parseBlock(node* parent)
 {
-    node block;
-    block.data.type = BLOCK;
-    block.length = 0;
-    block.children = (node*) malloc(sizeof(node));
+    node* block = addChild(parent);
+    block->data.type = BLOCK;
+    block->length = 0;
+    block->children = (node*) malloc(sizeof(node));
 
 
     if (tokenListManager.tokens[tokenListManager.index].type != LBRACE) {
@@ -318,15 +325,7 @@ node parseBlock()
     }
     tokenListManager.index++;
 
-    node* statementList = parseStatementList();
-
-    int len = 0;
-    for (int i = 0; statementList[i].data.type != EOF; i++) {
-        len++;
-    }
-    addNChildren(block, statementList, len);
-    printf("Destroy statementList %x\n", statementList);
-    free(statementList);
+    parseStatementList(block);
 
     if (tokenListManager.tokens[tokenListManager.index].type != RBRACE) {
         printf("Error: Expected '}' at line %d\n",
@@ -335,24 +334,18 @@ node parseBlock()
     }
     tokenListManager.index++;
 
-    return block;
+    return;
 }
 
-void parseProgram(node root)
+void parseProgram(node* rootRef)
 {
-    node* statementList = parseStatementList();
+    parseStatementList(rootRef);
 
     if (tokenListManager.tokens[tokenListManager.index].type == RBRACE) {
         printf("Error: Unexpected '}' at line %d\n",
             tokenListManager.tokens[tokenListManager.index].line);
         exit(1);
     }
-
-    int len = 0;
-    for (int i = 0; statementList[i].data.type != EOF; i++) {
-        len++;
-    }
-    addNChildren(root, statementList, len);
 
     return;
 }
@@ -367,9 +360,20 @@ node runParser(Token *tokenList)
     node ASTRoot;
     ASTRoot.data.type = ROOT;
     printf("%d\n", sizeof(node));
+    ASTRoot.length = 0;
     ASTRoot.children = (node*) malloc(sizeof(node));
 
-    parseProgram(ASTRoot);
+    parseProgram(&ASTRoot);
 
     return ASTRoot;
 }
+/*
+void iterateOverAST(node ast, void (*callback)(node, int), int depth)
+{
+    callback(ast, depth);
+    for (int i = 0; i < ast.length; i++) {
+        iterateOverAST(ast.children[i], callback, depth + 1);
+    }
+    return;
+}
+*/

--- a/src/parser.h
+++ b/src/parser.h
@@ -15,8 +15,9 @@ typedef struct Node {
     int length;
 } node;
 
-void addChild(node parent, node child);
+node* addChild(node* parent);
 
+void parseExpression(node* parent);
 
 node runParser(Token *tokens);
 


### PR DESCRIPTION
Returning nodes so that they are assigned (by the addChild function) to the memory space that corresponds to the children of the parent node is not only an inefficient solution, but also makes code debugging more difficult due to a more confusing flow of information.
Workaround applied was to pass parent node reference to simplify memory operations in instruction parser